### PR TITLE
don't specificy compat for a single node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt mochaTest mocha_phantomjs"
   },
   "engines": {
-    "node" : "~5.9.0"
+    "node" : ">=4"
   },
   "main": "lib/index.js"
 }


### PR DESCRIPTION
So one can install this module in newer versions of Node.js. I didn't test it in 4.x but I assume no issues. If you want to specifically require node 5.9.x or greater, `>=5.9.0` could also work.